### PR TITLE
double footer fix

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -49,5 +49,3 @@
     </div>
   </section>
 </div>
-
-<%= render "shared/footer" %>


### PR DESCRIPTION
I deleted one render footer from the home page as it was already in the layouts and it was displayed double